### PR TITLE
Support schema from .sql file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Given this information, the application will produce a SQL query suitable for th
 
 ## Project Goals
 - Provide a simple command line interface.
-- Accept engine name and schema as inputs.
+- Accept engine name and schema as inputs. The schema may be given
+  directly or loaded from a `.sql` file.
 - Translate a natural language question into a SQL query.
 
 Development is currently in a planning phase. Implementation details and usage instructions will be added as the project evolves.
@@ -44,4 +45,11 @@ You can also count rows:
 
 ```bash
 python -m esekuele.cli --schema "orders(id int, amount int)" "how many orders"
+```
+
+You can also provide the schema in a file:
+
+```bash
+echo "products(id int, price int)" > schema.sql
+python -m esekuele.cli --schema schema.sql "list all products"
 ```

--- a/esekuele/cli.py
+++ b/esekuele/cli.py
@@ -1,6 +1,7 @@
 import click
 from . import __version__
 from .generator import generate_sql
+from .schema import load_schema
 
 
 @click.command()
@@ -10,7 +11,8 @@ from .generator import generate_sql
 @click.version_option(version=__version__)
 def main(engine: str, schema: str, prompt: str) -> None:
     """Generate a SQL query for the given PROMPT."""
-    query = generate_sql(engine, schema, prompt)
+    schema_text = load_schema(schema)
+    query = generate_sql(engine, schema_text, prompt)
     click.echo(query)
 
 

--- a/esekuele/schema.py
+++ b/esekuele/schema.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 
@@ -5,4 +6,16 @@ def extract_table_names(schema: str) -> list[str]:
     """Return a list of table names found in a simple schema string."""
     names = re.findall(r"(\w+)\s*\(", schema)
     return names
+
+
+def load_schema(value: str) -> str:
+    """Return schema text from VALUE or load it from a .sql file.
+
+    If VALUE points to an existing file with a ``.sql`` extension, the file
+    contents are returned. Otherwise ``VALUE`` is returned unchanged.
+    """
+    if value.endswith(".sql") and os.path.isfile(value):
+        with open(value, "r", encoding="utf-8") as f:
+            return f.read()
+    return value
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,3 +25,21 @@ def test_generate_count():
     assert result.exit_code == 0
     assert 'SELECT COUNT(*) FROM orders;' in result.output
 
+
+def test_schema_from_file():
+    runner = CliRunner()
+    import tempfile
+    import os
+    with tempfile.NamedTemporaryFile('w', suffix='.sql', delete=False) as tmp:
+        tmp.write('items(id int)')
+        path = tmp.name
+    try:
+        result = runner.invoke(
+            main,
+            ['--schema', path, '--engine', 'sqlite', 'list all items']
+        )
+        assert result.exit_code == 0
+        assert 'SELECT * FROM items;' in result.output
+    finally:
+        os.remove(path)
+


### PR DESCRIPTION
## Summary
- load schema from `.sql` files when given
- use new loader in CLI
- test schema file path handling
- document file-based schema usage

## Testing
- `./pytest -q`