### PR TITLE
Add env support for OpenAI API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example configuration for Esekuele
+# Copy to .env and insert your OpenAI API key
+OPENAI_API_KEY=your-openai-key

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Esekuele
 
-Esekuele is a command line tool designed to generate SQL queries from natural language prompts. The CLI accepts a database engine name, a SQL schema describing the tables and columns, and a prompt that states a question to be answered.
+Esekuele is a command line tool designed to generate SQL queries from natural language prompts. The CLI accepts a database engine name, a SQL schema describing the tables and columns, a provider name, and a prompt that states a question to be answered.
 
 Given this information, the application will produce a SQL query suitable for the specified engine that should resolve the question described in the prompt.
 
@@ -21,6 +21,10 @@ The planned code layout is:
 - `esekuele/generator.py` – logic for calling the language model and formatting the resulting SQL
 
 Additional modules and tests will be added as the project evolves.
+
+The application supports multiple query generation providers. The default
+``regex`` provider uses simple pattern matching while ``openai`` delegates
+the task to the OpenAI API. Select a provider with the ``--provider`` option.
 
 ## Installation
 Create a virtual environment and install dependencies from ``requirements.txt``:
@@ -44,4 +48,18 @@ You can also count rows:
 
 ```bash
 python -m esekuele.cli --schema "orders(id int, amount int)" "how many orders"
+```
+
+Use the OpenAI provider:
+
+```bash
+python -m esekuele.cli --provider openai --schema "users(id int, name text)" "list all users"
+```
+
+Set the ``OPENAI_API_KEY`` environment variable so the provider can
+authenticate with the OpenAI API. You may place it in a ``.env`` file at
+the project root:
+
+```bash
+echo "OPENAI_API_KEY=your-key-here" > .env
 ```

--- a/esekuele/cli.py
+++ b/esekuele/cli.py
@@ -6,11 +6,12 @@ from .generator import generate_sql
 @click.command()
 @click.option('--engine', default='sqlite', show_default=True, help='SQL engine name')
 @click.option('--schema', required=True, help='Schema description')
+@click.option('--provider', default='regex', show_default=True, help='Query generation provider')
 @click.argument('prompt')
 @click.version_option(version=__version__)
-def main(engine: str, schema: str, prompt: str) -> None:
+def main(engine: str, schema: str, provider: str, prompt: str) -> None:
     """Generate a SQL query for the given PROMPT."""
-    query = generate_sql(engine, schema, prompt)
+    query = generate_sql(engine, schema, prompt, provider)
     click.echo(query)
 
 

--- a/esekuele/generator.py
+++ b/esekuele/generator.py
@@ -1,23 +1,77 @@
+from __future__ import annotations
+
 import re
+from typing import Dict
+
 from .schema import extract_table_names
 
 
-def generate_sql(engine: str, schema: str, prompt: str) -> str:
-    """Return a simple SQL query for the given prompt.
+class Provider:
+    """Base class for SQL generation providers."""
 
-    The implementation recognizes prompts asking to list all rows or count
-    rows from a table that appears in the provided schema. If no table is
-    recognized, a dummy query is returned.
-    """
-    tables = extract_table_names(schema)
-    for table in tables:
-        list_pattern = rf"(list|show).*{table}"
-        if re.search(list_pattern, prompt, re.IGNORECASE):
-            return f"SELECT * FROM {table};"
+    def generate(self, engine: str, schema: str, prompt: str) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
 
-        count_pattern = rf"(count|how many).*{table}"
-        if re.search(count_pattern, prompt, re.IGNORECASE):
-            return f"SELECT COUNT(*) FROM {table};"
 
-    return "SELECT 1;"
+class RegexProvider(Provider):
+    """Simple regex-based implementation used as a fallback."""
 
+    def generate(self, engine: str, schema: str, prompt: str) -> str:
+        tables = extract_table_names(schema)
+        for table in tables:
+            list_pattern = rf"(list|show).*{table}"
+            if re.search(list_pattern, prompt, re.IGNORECASE):
+                return f"SELECT * FROM {table};"
+
+            count_pattern = rf"(count|how many).*{table}"
+            if re.search(count_pattern, prompt, re.IGNORECASE):
+                return f"SELECT COUNT(*) FROM {table};"
+
+        return "SELECT 1;"
+
+
+class OpenAIProvider(Provider):
+    """Provider that delegates query generation to the OpenAI API."""
+
+    def __init__(self, model: str = "gpt-3.5-turbo", api_key: str | None = None):
+        self.model = model
+        self.api_key = api_key
+
+    def generate(self, engine: str, schema: str, prompt: str) -> str:
+        import os
+        import openai  # imported here to allow testing without the package installed
+
+        openai.api_key = self.api_key or os.getenv("OPENAI_API_KEY")
+        system_prompt = (
+            "You are a SQL assistant. "
+            f"Use the {engine} dialect. The database schema is: {schema}."
+        )
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ]
+        response = openai.ChatCompletion.create(model=self.model, messages=messages)
+        return response["choices"][0]["message"]["content"].strip()
+
+
+PROVIDERS: Dict[str, Provider] = {
+    "regex": RegexProvider(),
+    "openai": OpenAIProvider(),
+}
+
+
+def register_provider(name: str, provider: Provider) -> None:
+    """Add a provider to the registry."""
+    PROVIDERS[name] = provider
+
+
+def get_provider(name: str) -> Provider:
+    return PROVIDERS[name]
+
+
+def generate_sql(
+    engine: str, schema: str, prompt: str, provider: str = "regex"
+) -> str:
+    """Return a SQL query for the given prompt using the selected provider."""
+    provider_obj = get_provider(provider)
+    return provider_obj.generate(engine, schema, prompt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click
 pytest
+openai

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 from click.testing import CliRunner
 from esekuele.cli import main
 from esekuele import __version__
+import sys
+import types
 
 
 def test_version_option():
@@ -24,4 +26,18 @@ def test_generate_count():
     result = runner.invoke(main, ['--schema', schema, 'how many orders'])
     assert result.exit_code == 0
     assert 'SELECT COUNT(*) FROM orders;' in result.output
+
+
+def test_cli_with_openai(monkeypatch):
+    class FakeChat:
+        @staticmethod
+        def create(model, messages):
+            return {"choices": [{"message": {"content": "SELECT 1;"}}]}
+
+    monkeypatch.setitem(sys.modules, 'openai', types.SimpleNamespace(ChatCompletion=FakeChat))
+    runner = CliRunner()
+    schema = 'users(id int, name text)'
+    result = runner.invoke(main, ['--provider', 'openai', '--schema', schema, 'list users'])
+    assert result.exit_code == 0
+    assert 'SELECT 1;' in result.output
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,47 @@
+import types
+import sys
+
+import pytest
+
+from esekuele.generator import generate_sql, OpenAIProvider
+
+
+def make_fake_openai(return_text="SELECT 1;"):
+    class FakeChat:
+        @staticmethod
+        def create(model, messages):
+            FakeChat.called_with = {"model": model, "messages": messages}
+            return {"choices": [{"message": {"content": return_text}}]}
+
+    return types.SimpleNamespace(ChatCompletion=FakeChat, api_key=None)
+
+
+def test_openai_provider(monkeypatch):
+    fake_openai = make_fake_openai("SELECT 42;")
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    provider = OpenAIProvider(model="test-model")
+    sql = provider.generate("sqlite", "users(id int)", "list users")
+    assert sql == "SELECT 42;"
+    assert fake_openai.ChatCompletion.called_with["model"] == "test-model"
+
+
+def test_openai_provider_reads_env(monkeypatch):
+    fake_openai = make_fake_openai()
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    monkeypatch.setenv("OPENAI_API_KEY", "abc123")
+    provider = OpenAIProvider()
+    provider.generate("sqlite", "users(id int)", "list users")
+    assert fake_openai.api_key == "abc123"
+
+
+def test_generate_sql_with_openai(monkeypatch):
+    fake_openai = make_fake_openai("SELECT * FROM users;")
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    sql = generate_sql(
+        "sqlite",
+        "users(id int, name text)",
+        "list users",
+        provider="openai",
+    )
+    assert sql == "SELECT * FROM users;"
+


### PR DESCRIPTION
## Summary
- allow `OpenAIProvider` to read `OPENAI_API_KEY` from the environment
- document key setup in README
- provide `.env.example` file
- test provider uses environment variable

## Testing
- `pytest -q` *(fails: command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.